### PR TITLE
Multiple messages per request, macros for handling tokens with DeviceNotRegistered errors, automatic instance building

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 charset = utf-8
 indent_size = 4
 indent_style = space
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     ],
     "require": {
         "php": ">=7.3",
-        "guzzlehttp/guzzle": "^7.3"
+        "guzzlehttp/guzzle": "^7.3",
+        "ext-json": "*",
+        "ext-zlib": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"

--- a/src/Expo.php
+++ b/src/Expo.php
@@ -163,11 +163,18 @@ class Expo
     /**
      * Sets the messages to send
      *
-     * @param ExpoMessage[]|ExpoMessage $message
+     * @param ExpoMessage[]|ExpoMessage|array $message
      */
     public function send($message): self
     {
-        $this->messages = Utils::arrayWrap($message);
+        $messages = Utils::arrayWrap($message);
+
+        foreach ($messages as $index => $message) {
+            if (!($message instanceof ExpoMessage))
+                $messages[$index] = new ExpoMessage($message);
+        }
+
+        $this->messages = $messages;
 
         return $this;
     }

--- a/src/Expo.php
+++ b/src/Expo.php
@@ -160,28 +160,7 @@ class Expo
      */
     public function to($recipients = null): self
     {
-        $tokens = null;
-
-        if (is_array($recipients) && count($recipients) > 0) {
-            $tokens = $recipients;
-        } elseif (is_string($recipients)) {
-            $tokens = [$recipients];
-        } else {
-            throw new InvalidTokensException(sprintf(
-                'Tokens must be a string or non empty array, %s given.',
-                gettype($tokens)
-            ));
-        }
-
-        $tokens = array_filter($tokens, function ($token) {
-            return Utils::isExpoPushToken($token);
-        });
-
-        if (count($tokens) === 0) {
-            throw new ExpoException('No valid expo tokens provided.');
-        }
-
-        $this->recipients = $tokens;
+        $this->recipients = Utils::validateTokens($recipients);
 
         return $this;
     }

--- a/src/Expo.php
+++ b/src/Expo.php
@@ -222,7 +222,7 @@ class Expo
          */
         foreach ($this->messages as $message) {
             $message = $message->toArray();
-            foreach (Utils::arrayWrap($message['to']) as $token) {
+            foreach (Utils::arrayWrap($message['to'] ?? $this->recipients) as $token) {
                 $messages[] = array_merge($message, ['to' => $token]);
             }
         }

--- a/src/ExpoClient.php
+++ b/src/ExpoClient.php
@@ -168,6 +168,13 @@ class ExpoClient
      */
     private function getActualMessageCount(array $messages): int
     {
-        return count($messages);
+        $count = 0;
+
+        foreach ($messages as $message) {
+            $recipients = Utils::arrayWrap($message['to']);
+            $count += count($recipients);
+        }
+
+        return $count;
     }
 }

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -12,6 +12,13 @@ use ExpoSDK\Exceptions\ExpoMessageException;
 class ExpoMessage
 {
     /**
+     * An Expo push token or an array of Expo push tokens specifying the recipient(s) of this message.
+     *
+     * @var string[]|null
+     */
+    private $to = null;
+
+    /**
      * A JSON object delivered to your app.
      * It may be up to about 4KiB; the total notification payload sent to Apple and Google must be at most 4KiB
      * or else you will get a "Message Too Big" error.
@@ -122,6 +129,24 @@ class ExpoMessage
      * @var bool
      */
     private $mutableContent = false;
+
+    /**
+     * Set recipients of the message
+     *
+     * @see to
+     *
+     * @throws \ExpoSDK\Exceptions\ExpoException
+     * @throws \ExpoSDK\Exceptions\InvalidTokensException
+     *
+     * @param  string[]|string  $tokens
+     *
+     * @return $this
+     */
+    public function setTo($tokens): self {
+        $this->to = Utils::validateTokens($tokens);
+
+        return $this;
+    }
 
     /**
      * Sets the data for the message

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -42,20 +42,17 @@ class ExpoMessage
     /**
      * Sets the data for the message
      *
+     * @param object|array|null $data
+     *
      * @throws ExpoMessageException
      */
-    public function setData(array $data): self
+    public function setData($data = null): self
     {
-        if (! Utils::isAssoc($data)) {
+        // allow null, objects and associative arrays
+        if ($data != null && !is_object($data) && !Utils::isAssoc($data)) {
             throw new ExpoMessageException(
-                'Message data must be an associative array.'
+                'Message data must be either associative array, object or null.'
             );
-        }
-
-        $data = json_encode($data);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new ExpoMessageException('Data could not be json encoded.');
         }
 
         $this->data = $data;

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -39,9 +39,17 @@ class ExpoMessage
      * Time to Live: the number of seconds for which the message may be kept around for redelivery if it hasn't been delivered yet.
      * Defaults to null in order to use the respective defaults of each provider (0 for iOS/APNs and 2419200 (4 weeks) for Android/FCM).
      *
-     * @var number|null
+     * @var int|null
      */
     private $ttl = null;
+
+    /**
+     * Timestamp since the UNIX epoch specifying when the message expires.
+     * Same effect as ttl (ttl takes precedence over expiration).
+     *
+     * @var int|null
+     */
+    private $expiration = null;
 
     /**
      * The delivery priority of the message.
@@ -178,6 +186,21 @@ class ExpoMessage
      */
     public function setTtl(int $ttl = null): self {
         $this->ttl = $ttl;
+
+        return $this;
+    }
+
+    /**
+     * Sets expiration time of the message
+     *
+     * @see expiration
+     *
+     * @param  int|null  $expiration
+     *
+     * @return $this
+     */
+    public function setExpiration(int $expiration = null): self {
+        $this->expiration = $expiration;
 
         return $this;
     }

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -4,55 +4,132 @@ namespace ExpoSDK;
 
 use ExpoSDK\Exceptions\ExpoMessageException;
 
+/**
+ * Implementation of Expo message request format
+ *
+ * @link https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format Expo Message request format
+ */
 class ExpoMessage
 {
-    /** @var null */
+    /**
+     * A JSON object delivered to your app.
+     * It may be up to about 4KiB; the total notification payload sent to Apple and Google must be at most 4KiB
+     * or else you will get a "Message Too Big" error.
+     *
+     * @var object|array|null
+     */
     private $data = null;
 
-    /** @var null */
+    /**
+     * The title to display in the notification.
+     * Often displayed above the notification body.
+     *
+     * @var string|null
+     */
     private $title = null;
 
-    /** @var null */
+    /**
+     * The message to display in the notification.
+     *
+     * @var string|null
+     */
     private $body = null;
 
-    /** @var null */
+    /**
+     * Time to Live: the number of seconds for which the message may be kept around for redelivery if it hasn't been delivered yet.
+     * Defaults to null in order to use the respective defaults of each provider (0 for iOS/APNs and 2419200 (4 weeks) for Android/FCM).
+     *
+     * @var number|null
+     */
     private $ttl = null;
 
-    /** @var string */
+    /**
+     * The delivery priority of the message.
+     * Specify "default" or omit this field to use the default priority on each platform ("normal" on Android and "high" on iOS).
+     *
+     * Supported: 'default', 'normal', 'high'.
+     *
+     * @var string
+     */
     private $priority = 'default';
 
-    /** @var null */
+    /**
+     * The subtitle to display in the notification below the title.
+     *
+     * iOS only.
+     *
+     * @var string|null
+     */
     private $subtitle = null;
 
-    /** @var null */
+    /**
+     * Play a sound when the recipient receives this notification.
+     * Specify "default" to play the device's default notification sound, or omit this field to play no sound.
+     * Custom sounds are not supported.
+     *
+     * iOS only.
+     *
+     * @var string|null
+     */
     private $sound = null;
 
-    /** @var null */
+    /**
+     * Number to display in the badge on the app icon.
+     * Specify zero to clear the badge.
+     *
+     * iOS only.
+     *
+     * @var numeric|null
+     */
     private $badge = null;
 
-    /** @var null */
+    /**
+     * ID of the Notification Channel through which to display this notification.
+     * If an ID is specified but the corresponding channel does not exist on the device (i.e. has not yet been created by your app),
+     * the notification will not be displayed to the user.
+     *
+     * Android only.
+     *
+     * @var string|null
+     */
     private $channelId = null;
 
-    /** @var null */
+    /**
+     * ID of the notification category that this notification is associated with.
+     * Must be on at least SDK 41 or bare workflow.
+     *
+     * @see https://docs.expo.dev/versions/latest/sdk/notifications/#managing-notification-categories-interactive-notifications Notification categories
+     *
+     * @var string|null
+     */
     private $categoryId = null;
 
-    /** @var bool */
+    /**
+     * Specifies whether this notification can be intercepted by the client app.
+     * In Expo Go, this defaults to true, and if you change that to false, you may experience issues.
+     * In standalone and bare apps, this defaults to false.
+     *
+     * iOS only.
+     *
+     * @var bool
+     */
     private $mutableContent = false;
 
     /**
      * Sets the data for the message
      *
-     * @param object|array|null $data
+     * @see data
      *
      * @throws ExpoMessageException
+     *
+     * @param  object|array|null  $data
+     *
+     * @return $this
      */
-    public function setData($data = null): self
-    {
+    public function setData($data = null): self {
         // allow null, objects and associative arrays
         if ($data != null && !is_object($data) && !Utils::isAssoc($data)) {
-            throw new ExpoMessageException(
-                'Message data must be either associative array, object or null.'
-            );
+            throw new ExpoMessageException('Message data must be either associative array, object or null.');
         }
 
         $this->data = $data;
@@ -62,9 +139,14 @@ class ExpoMessage
 
     /**
      * Sets the title to display in the notification
+     *
+     * @see title
+     *
+     * @param  string|null  $title
+     *
+     * @return $this
      */
-    public function setTitle(string $title): self
-    {
+    public function setTitle(string $title = null): self {
         $this->title = $title;
 
         return $this;
@@ -72,9 +154,14 @@ class ExpoMessage
 
     /**
      * Sets the message to display in the notification
+     *
+     * @see body
+     *
+     * @param  string|null  $body
+     *
+     * @return $this
      */
-    public function setBody(string $body): self
-    {
+    public function setBody(string $body = null): self {
         $this->body = $body;
 
         return $this;
@@ -82,9 +169,14 @@ class ExpoMessage
 
     /**
      * Sets the number of seconds for which the message may be kept around for redelivery
+     *
+     * @see ttl
+     *
+     * @param  int|null  $ttl
+     *
+     * @return $this
      */
-    public function setTtl(int $ttl): self
-    {
+    public function setTtl(int $ttl = null): self {
         $this->ttl = $ttl;
 
         return $this;
@@ -93,16 +185,19 @@ class ExpoMessage
     /**
      * Sets the delivery priority of the message, either 'default', 'normal' or 'high
      *
+     * @see priority
+     *
      * @throws ExpoMessageException
+     *
+     * @param  string  $priority
+     *
+     * @return $this
      */
-    public function setPriority(string $priority): self
-    {
+    public function setPriority(string $priority = 'default'): self {
         $priority = strtolower($priority);
 
-        if (! in_array($priority, ['default', 'normal', 'high'])) {
-            throw new ExpoMessageException(
-                'Priority must be default, normal or high.'
-            );
+        if (!in_array($priority, ['default', 'normal', 'high'])) {
+            throw new ExpoMessageException('Priority must be default, normal or high.');
         }
 
         $this->priority = $priority;
@@ -112,9 +207,14 @@ class ExpoMessage
 
     /**
      * Sets the subtitle to display in the notification below the title
+     *
+     * @see subtitle
+     *
+     * @param  string|null  $subtitle
+     *
+     * @return $this
      */
-    public function setSubtitle(string $subtitle): self
-    {
+    public function setSubtitle(string $subtitle = null): self {
         $this->subtitle = $subtitle;
 
         return $this;
@@ -122,9 +222,12 @@ class ExpoMessage
 
     /**
      * Play a sound when the recipient receives the notification
+     *
+     * @see sound
+     *
+     * @return $this
      */
-    public function playSound(): self
-    {
+    public function playSound(): self {
         $this->sound = 'default';
 
         return $this;
@@ -132,9 +235,14 @@ class ExpoMessage
 
     /**
      * Set the number to display in the badge on the app icon
+     *
+     * @see badge
+     *
+     * @param  int|null  $badge
+     *
+     * @return $this
      */
-    public function setBadge(int $badge): self
-    {
+    public function setBadge(int $badge = null): self {
         $this->badge = $badge;
 
         return $this;
@@ -142,9 +250,14 @@ class ExpoMessage
 
     /**
      * Set the ID of the Notification Channel through which to display this notification
+     *
+     * @see channelId
+     *
+     * @param  string|null  $channelId
+     *
+     * @return $this
      */
-    public function setChannelId(string $channelId): self
-    {
+    public function setChannelId(string $channelId = null): self {
         $this->channelId = $channelId;
 
         return $this;
@@ -152,9 +265,14 @@ class ExpoMessage
 
     /**
      * Set the ID of the notification category that this notification is associated with
+     *
+     * @see categoryId
+     *
+     * @param  string|null  $categoryId
+     *
+     * @return $this
      */
-    public function setCategoryId(string $categoryId): self
-    {
+    public function setCategoryId(string $categoryId = null): self {
         $this->categoryId = $categoryId;
 
         return $this;
@@ -162,9 +280,14 @@ class ExpoMessage
 
     /**
      * Set whether the notification can be intercepted by the client app
+     *
+     * @see mutableContent
+     *
+     * @param  bool  $mutable
+     *
+     * @return $this
      */
-    public function setMutableContent(bool $mutable): self
-    {
+    public function setMutableContent(bool $mutable): self {
         $this->mutableContent = $mutable;
 
         return $this;
@@ -172,13 +295,15 @@ class ExpoMessage
 
     /**
      * Convert the message to an array
+     * Skips properties with 'null' values
+     *
+     * @return array
      */
-    public function toArray(): array
-    {
+    public function toArray(): array {
         $attributes = [];
 
         foreach ($this as $key => $value) {
-            if (! is_null($value)) {
+            if (!is_null($value)) {
                 $attributes[$key] = $value;
             }
         }

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -130,6 +130,17 @@ class ExpoMessage
      */
     private $mutableContent = false;
 
+    public function __construct(array $args = []) {
+        foreach ($args as $key => $value) {
+            $method = 'set' . ucfirst($key);
+
+            // all properties without setters will be skipped
+            if (method_exists($this, $method)) {
+                $this->{$method}($value);
+            }
+        }
+    }
+
     /**
      * Set recipients of the message
      *

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -234,6 +234,22 @@ class ExpoMessage
     }
 
     /**
+     * Sets sound to specific value
+     *
+     * @see sound
+     * @see playSound()
+     *
+     * @param  string|null  $sound
+     *
+     * @return $this
+     */
+    public function setSound(string $sound = null): self {
+        $this->sound = $sound;
+
+        return $this;
+    }
+
+    /**
      * Set the number to display in the badge on the app icon
      *
      * @see badge

--- a/src/Traits/Macroable.php
+++ b/src/Traits/Macroable.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace ExpoSDK\Traits;
+
+use BadMethodCallException;
+use Closure;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * @see https://github.com/spatie/macroable/blob/main/src/Macroable.php Source code at Laravel's GitHub
+ */
+trait Macroable
+{
+    protected static $macros = [];
+
+    public static function macro(string $name, callable $macro): void
+    {
+        static::$macros[$name] = $macro;
+    }
+
+    public static function mixin($mixin): void
+    {
+        $methods = (new ReflectionClass($mixin))->getMethods(
+            ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
+        );
+
+        foreach ($methods as $method) {
+            $method->setAccessible(true);
+
+            static::macro($method->name, $method->invoke($mixin));
+        }
+    }
+
+    public static function hasMacro(string $name): bool
+    {
+        return isset(static::$macros[$name]);
+    }
+
+    public static function __callStatic($method, $parameters)
+    {
+        if (! static::hasMacro($method)) {
+            throw new BadMethodCallException("Method {$method} does not exist.");
+        }
+
+        $macro = static::$macros[$method];
+
+        if ($macro instanceof Closure) {
+            return call_user_func_array(Closure::bind($macro, null, static::class), $parameters);
+        }
+
+        return call_user_func_array($macro, $parameters);
+    }
+
+    public function __call($method, $parameters)
+    {
+        if (! static::hasMacro($method)) {
+            throw new BadMethodCallException("Method {$method} does not exist.");
+        }
+
+        $macro = static::$macros[$method];
+
+        if ($macro instanceof Closure) {
+            return call_user_func_array($macro->bindTo($this, static::class), $parameters);
+        }
+
+        return call_user_func_array($macro, $parameters);
+    }
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,6 +2,9 @@
 
 namespace ExpoSDK;
 
+use ExpoSDK\Exceptions\ExpoException;
+use ExpoSDK\Exceptions\InvalidTokensException;
+
 class Utils
 {
     /**
@@ -47,5 +50,46 @@ class Utils
     {
         return $needle !== '' &&
             substr($haystack, -strlen($needle)) === (string) $needle;
+    }
+
+    /**
+     * Wrap data in array if data is not an array
+     *
+     * @param array|mixed $data
+     *
+     * @return array
+     */
+    public static function arrayWrap($data): array
+    {
+        return is_array($data) ? $data : [$data];
+    }
+
+    /**
+     * Validates and filters tokens for later use
+     *
+     * @throws \ExpoSDK\Exceptions\ExpoException
+     * @throws \ExpoSDK\Exceptions\InvalidTokensException
+     *
+     * @param string[]|string $tokens
+     *
+     * @return string[]
+     */
+    public static function validateTokens($tokens): array {
+        if (!is_array($tokens) && !is_string($tokens)) {
+            throw new InvalidTokensException(sprintf(
+                'Tokens must be a string or non empty array, %s given.',
+                gettype($tokens)
+            ));
+        }
+
+        $tokens = array_filter(Utils::arrayWrap($tokens), function ($token) {
+            return Utils::isExpoPushToken($token);
+        });
+
+        if (count($tokens) === 0) {
+            throw new ExpoException('No valid expo tokens provided.');
+        }
+
+        return $tokens;
     }
 }


### PR DESCRIPTION
This PR adds next features:

### Ability to set a bunch of messages before making a request.
```php
$messages = [];

$messages[] = (new ExpoMessage())
    ->setTitle('random title')
    ->setTo(['ExponentPushToken[vwskdcfnkal]', 'ExponentPushToken[kljmfwe32rklowm]']);

$messages[] = (new ExpoMessage())
    ->setTitle('another notification')
    ->setTo('ExponentPushToken[single-recipient]');

$messages[] = (new ExpoMessage())
    ->setTitle('notification with default recipients');

(new Expo())->send($messages)->to(['ExponentPushToken[default-recipients-here]'])->push();
```

### Ability to pass array of data in both ExpoMessage constructor and Expo send() method, without creating instances manually.
```php
$messages = [];

// ExpoMessage can be created automatiaclly
$messages[] = [
    'title' => 'test title',
    'body' => 'test body',
    'to' => 'ExponentPushToken[kjsdnfjkasnekf]',
    'data' => ['some' => 'data'],
];
// or be instantiated manually
$messages[] = (new ExpoMessage([
    'title' => 'Test not123123',
    'body' => 'Test body123123123',
]))->setTitle('this title will override initial one'),

(new Expo)->send($messages)->push();
```

### Introduces two macros for handling tokens with DeviceNotRegistered errors.
You can register them somewhere in the beginning of request life cycle and its callbacks will be called for all invalid tokens.
```php
Expo::addDevicesNotRegisteredHandler(function ($tokens) {
    // this callback is called once and it recieves array of invalid tokens
});
Expo::addDeviceNotRegisteredHandler(function ($token) {
    // this callback is called for each token separately and only if previous macro is not registered
});
```