### PR TITLE
Allow lowest guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "guzzlehttp/guzzle": ">=6.0.0",
+        "guzzlehttp/guzzle": "^6|^7",
         "ext-json": "*",
         "ext-zlib": "*"
     },


### PR DESCRIPTION
Your package doesn't need the latest version of Guzzle and this will easier the way to add your package in an old project.

Thanks for this package, it's very useful. 