### PR TITLE
use token from error details, if provided

### DIFF
--- a/src/Expo.php
+++ b/src/Expo.php
@@ -244,7 +244,7 @@ class Expo
 
             foreach ($response->getData() as $index => $ticket) {
                 if (($ticket['details']['error'] ?? '') === 'DeviceNotRegistered') {
-                    $notRegisteredTokens[] = $messages[$index]['to'];
+                    $notRegisteredTokens[] = $ticket['details']['expoPushToken'] ?? $messages[$index]['to'];
                 }
             }
 


### PR DESCRIPTION
@ctwillie I noticed that the ticket error details from the expo api now include `expoPushToken` at least when the type is `DeviceNotRegistered`.