### PR TITLE
Adds _contentAvailable parameter to ExpoMassage

### DIFF
--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -130,6 +130,15 @@ class ExpoMessage
      */
     private $mutableContent = false;
 
+    /**
+     * It tells iOS that the application has to wake up when a notification is received. It has to be true if you want to handle push notification receiving with a background task.
+     *
+     * iOS only.
+     *
+     * @var bool
+     */
+    private $_contentAvailable = false;
+
     public function __construct(array $attributes = [])
     {
         foreach ($attributes as $key => $value) {
@@ -384,6 +393,22 @@ class ExpoMessage
     public function setMutableContent(bool $mutable): self
     {
         $this->mutableContent = $mutable;
+
+        return $this;
+    }
+
+    /**
+     * Set whether the notification can be wake up the application. iOS only
+     *
+     * @see _contentAvailable
+     *
+     * @param  bool  $isContentAvailable
+     *
+     * @return $this
+     */
+    public function set_contentAvailable(bool $isContentAvailable): self
+    {
+        $this->_contentAvailable = $isContentAvailable;
 
         return $this;
     }

--- a/tests/ExpoMessageTest.php
+++ b/tests/ExpoMessageTest.php
@@ -29,7 +29,8 @@ class ExpoMessageTest extends TestCase
             ->setBadge(0)
             ->setChannelId('default')
             ->setCategoryId('category-id')
-            ->setMutableContent(true);
+            ->setMutableContent(true)
+            ->set_contentAvailable(true);
 
         $this->assertSame(
             [
@@ -43,6 +44,7 @@ class ExpoMessageTest extends TestCase
                 "channelId" => "default",
                 "categoryId" => "category-id",
                 "mutableContent" => true,
+                "_contentAvailable" => true,
             ],
             $message->toArray()
         );
@@ -82,6 +84,7 @@ class ExpoMessageTest extends TestCase
             'body' => 'test body',
             'data' => [],
             'to' => ['ExponentPushToken[valid-token]', 'invalid-token]'],
+            '_contentAvailable' => true,
         ]))->toArray();
         $expected = [
             'mutableContent' => false,
@@ -90,6 +93,7 @@ class ExpoMessageTest extends TestCase
             'body' => 'test body',
             'data' => new \stdClass(),
             'to' => ['ExponentPushToken[valid-token]'],
+            '_contentAvailable' => true,
         ];
 
         asort($expected);


### PR DESCRIPTION
This parameter doesn't appear in the docs of expo API but it handles it and it's work. It has to be true if you want to handle the notification receiving with background tasks on iOS.