### PR TITLE
Add _contentAvailable flag for iOS background notifications

### DIFF
--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -130,6 +130,19 @@ class ExpoMessage
      */
     private $mutableContent = false;
 
+    /**
+     * Specifies whether this notification should be handled by apps with background notifications
+     * enabled on iOS. Defaults to false.
+     *
+     * To enable iOS background notifications handling, read the documentation:
+     * https://docs.expo.dev/versions/latest/sdk/notifications/#background-events
+     *
+     * iOS only.
+     *
+     * @var bool
+     */
+    private $_contentAvailable = false;
+
     public function __construct(array $attributes = [])
     {
         foreach ($attributes as $key => $value) {
@@ -384,6 +397,22 @@ class ExpoMessage
     public function setMutableContent(bool $mutable): self
     {
         $this->mutableContent = $mutable;
+
+        return $this;
+    }
+
+    /**
+     * Set whether the notification should be handled by apps with background notifications enabled.
+     *
+     * @param   bool  $contentAvailable
+     *
+     * @return $this
+     *
+     * @see _contentAvailable
+     */
+    public function setContentAvailable(bool $contentAvailable): self
+    {
+        $this->_contentAvailable = $contentAvailable;
 
         return $this;
     }

--- a/tests/ExpoMessageTest.php
+++ b/tests/ExpoMessageTest.php
@@ -29,7 +29,8 @@ class ExpoMessageTest extends TestCase
             ->setBadge(0)
             ->setChannelId('default')
             ->setCategoryId('category-id')
-            ->setMutableContent(true);
+            ->setMutableContent(true)
+            ->setContentAvailable(true);
 
         $this->assertSame(
             [
@@ -43,6 +44,7 @@ class ExpoMessageTest extends TestCase
                 "channelId" => "default",
                 "categoryId" => "category-id",
                 "mutableContent" => true,
+                "_contentAvailable" => true,
             ],
             $message->toArray()
         );
@@ -82,6 +84,7 @@ class ExpoMessageTest extends TestCase
             'body' => 'test body',
             'data' => [],
             'to' => ['ExponentPushToken[valid-token]', 'invalid-token]'],
+            '_contentAvailable' => true,
         ]))->toArray();
         $expected = [
             'mutableContent' => false,
@@ -90,6 +93,7 @@ class ExpoMessageTest extends TestCase
             'body' => 'test body',
             'data' => new \stdClass(),
             'to' => ['ExponentPushToken[valid-token]'],
+            '_contentAvailable' => true,
         ];
 
         asort($expected);


### PR DESCRIPTION
Please refer to notifications documentation here https://docs.expo.dev/versions/latest/sdk/notifications/#background-events Related issue https://github.com/expo/expo/issues/13767#issuecomment-1666138867